### PR TITLE
Add CPD support for WD BYOS

### DIFF
--- a/integrations/extensions/starter-kits/watson-discovery/README.md
+++ b/integrations/extensions/starter-kits/watson-discovery/README.md
@@ -41,9 +41,9 @@ More broadly, anything you can do with Watson Discovery parameters and Watson Di
 
 ### Setting up Watson Discovery
 
-Before starting, you will need an instance of [IBM Watson Discovery](https://www.ibm.com/cloud/watson-discovery), and you will need the API key and instance ID for that instance.  You will also need to know the region where the instance is located, which is found in the URL for the instance immediately after `https://api.` For example if the URL for your instance is `https://api.us-south.discovery.watson.cloud.ibm.com/instances/447fc929-fde9-402e-b73c-03274b8ab0bb`, then the region where your instance is located is `us-south` and your instance ID is `447fc929-fde9-402e-b73c-03274b8ab0bb`.  The URL and API key are both found in the "Credentials" section of the resource page for the instance in IBM Cloud.
+Before starting, you will need an instance of [IBM Watson Discovery](https://www.ibm.com/cloud/watson-discovery).  You will also need the URL for that instance and either an API key or a bearer token for that instance.  Typically API keys are used for IBM Cloud instances and bearer tokens are used for instances running in Cloud Pak for Data outside of the IBM Cloud.  Both the URL and the API key or bearer token are found on the credentials page for the instance on IBM Cloud or on Cloud Pak for Data.
 
-You will also need to load some data into IBM Watson Discovery.  The example actions in this starter kit were tested on an IBM Watson Discovery project in which we ingested the page `https://bitcoin.org/en/faq` and configured Discovery to follow 0 links (i.e., load that one page only) with FAQ Extraction enabled to split that page into multiple question/answer pairs.  For more details on FAQ Extraction in Watson Discovery, see [Turn your FAQ pages into conversational AI](https://medium.com/ibm-watson/turn-your-faq-pages-into-conversational-ai-8ac7ae7ec793).  To try out this starter kit, you can also ingest that example page, or you can connect directly to your own data and modify the details of the starter kit as needed to be relevant to your data.
+You will also need to load some data into IBM Watson Discovery.  The example actions in this starter kit were tested on an IBM Watson Discovery project in which we ingested the page `https://bitcoin.org/en/faq` and configured Discovery to follow 0 links (i.e., load that one page only).  To try out this starter kit, you can also ingest that example page, or you can connect directly to your own data and modify the details of the starter kit as needed to be relevant to your data.
 
 ## Other Setup Info
 
@@ -55,12 +55,14 @@ If you want to make a _new_ Assistant using this starter kit, take the following
    - The `watson-discovery-query-actions-generic.json` actions file uses search only when no action matches and does not apply any filters on the search -- it just searches a complete project.  It is a general purpose solution usable with any data set.
    - The `watson-discovery-query-actions-with-examples.json` actions file includes everything in the generic actions file _plus_ some specialized examples that show the use of filters and other customization for particular settings or intents.  See the "Exploring the actions in the actions file with examples" section of this document for more details.
 - Use the OpenAPI specification to [build a custom extension](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-build-custom-extension#building-the-custom-extension).
-- [Add the extension to your assistant](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-add-custom-extension) using the API key and region you obtained in the pre-requisites above.  When you select basic authentication, it will ask for a username and password.  For the username, enter `apikey` and for the password enter the API key you obtained in the pre-requisites above.  Also fill in the region you obtained in the pre-requisites into the `subdomain` server variable (the default is `us-south`, so if your instance is in a different region, you will need to change this value).
+- [Add the extension to your assistant](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-add-custom-extension) using the API key and region you obtained in the pre-requisites above.
+   - If you have an API key (as typical on IBM Cloud), select basic authentication, and it will ask for a username and password; for the username, enter `apikey` and for the password enter the API key you obtained in the pre-requisites above.  
+   - If you have a bearer token (as typical on Cloud Pak for Data), select bearer authentication, and it will ask for your bearer token.
+   - Also fill in the portions of the URL for your instance _after_ `https://` in the `discovery_url` field.
 - [Upload the Actions JSON file](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-admin-backup-restore#backup-restore-import).
 - Under "variables"/"created by you" (within the Actions page), set the using the `discovery_instance_id` and `discovery_project_id` session variables using the values you obtained in the pre-requisites above.
-- Use either method listed in [Configuring Your Actions Skill to use an Extension](https://github.com/watson-developer-cloud/assistant-toolkit/blob/master/integrations/extensions/README.md#configuring-your-actions-skill-to-use-an-extension) to configure the actions you uploaded to invoke the custom extension you built.
+- If you are using the OpenAPI specification _exactly_ as it is in this starter kit, you should find that your actions are correctly configured to use this extension as is.  However, if you have made any changes to the OpenAPI specification, you will need to manually configure your search action as follows:
    - In the step of the "Search" action that says "Use an extension", select the extension you created, the "Query a project" endpoint, and set the following parameter values (some of which are listed under "optional parameters", which you need to click on to see):
-      - `instance_id` = the `discovery_instance_id` session variable
       - `project_id` = the `discovery_project_id` session variable
       - `version` = the `discovery_date_version` session variable
       - `count` = an expression with the value `3` (because we are showing up to 3 results -- adjust this if you want to show a different number)
@@ -73,14 +75,14 @@ If you want to make a _new_ Assistant using this starter kit, take the following
       - `natural_language_query` = the `query_text` session variable
    - If you used the actions file with examples (`watson-discovery-query-actions-with-examples.json`) you also need to setup some domain-specific example actions:
       - In the extension step of the "Search within the mining topic" action, set all the same values as "Search" plus the following:
-         - `filter` = an expression with the value `title:mining`
+         - `filter` = an expression with the value `mining`
       - In the extension step of the "How many Bitcoins can exist?" action, set all the same values as "Search" plus the following:
         - `count` = an expression with the value `1` (instead of the `3` in search)
-        - `filter` = an expression with the value `title:finite`
+        - `filter` = an expression with the value `finite`
 
 ### Setup in a pre-existing Assistant
 
-If you want to add this starter kit to an _existing_ assistant, you cannot use the Actions JSON file since it will overwrite your existing configuration. Anyone wanting to add this capability to an existing bot may thus want to start by setting up the starter kit in a new Assistant (as described in the previous section), spend some time looking at how it works and what it does, and then apply what was learned to their own assistant.  You should be able to use the OpenAPI specification (`watson-discovery-query-openapi.json`) to [build a custom extension](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-build-custom-extension#building-the-custom-extension) without making any changes to it.  However, you will need to make your own Actions, including the ones in the generic actions file and perhaps some that are inspired by the additional examples in the "with examples" actions file.
+If you want to add this starter kit to an _existing_ assistant, you cannot use the Actions JSON file since it will overwrite your existing configuration. Anyone wanting to add this capability to an existing bot may thus want to start by setting up the starter kit in a new Assistant (as described in the previous section), spend some time looking at how it works and what it does, and then apply what was learned to their existing assistant.  You should be able to use the OpenAPI specification (`watson-discovery-query-openapi.json`) to [build a custom extension](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-build-custom-extension#building-the-custom-extension) without making any changes to it.  However, you will need to make your own Actions, including the ones in the generic actions file and perhaps some that are inspired by the additional examples in the "with examples" actions file.
 
 ### (Optional/Advanced) Setup the sample index.html file
 

--- a/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-actions-generic.json
+++ b/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-actions-generic.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2022-10-24T19:24:31.115Z",
-  "updated": "2022-10-24T19:51:15.063Z",
+  "created": "2023-03-08T18:32:52.647Z",
+  "updated": "2023-03-08T20:18:02.685Z",
   "language": "en",
-  "skill_id": "895e855a-ca58-4ef0-a7f6-229c6341884d",
+  "skill_id": "b9bded36-8ca5-4e17-8a87-4f26e004e229",
   "workspace": {
     "actions": [
       {
@@ -763,11 +763,12 @@
             "resolver": {
               "type": "callout",
               "callout": {
-                "path": "/instances/{instance_id}/v2/projects/{project_id}/query",
+                "path": "/v2/projects/{project_id}/query",
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "catalog_item_id": "aac950c3-3bb0-4130-b45b-c5dfddfc6ed7"
+                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
+                  "catalog_item_id": "ca62ae92-447b-44a4-af23-3a239ae8eb2f"
                 },
                 "request_mapping": {
                   "body": [
@@ -779,25 +780,19 @@
                     },
                     {
                       "value": {
-                        "expression": "3"
+                        "expression": "[\"title\",\"metadata.source.url\"]"
                       },
-                      "parameter": "offset"
+                      "parameter": "return"
                     },
                     {
                       "value": {
-                        "expression": "false"
+                        "expression": "[\"text\"]"
                       },
-                      "parameter": "similar.enabled"
+                      "parameter": "passages.fields"
                     },
                     {
                       "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "passages.count"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"True\""
+                        "expression": "true"
                       },
                       "parameter": "passages.enabled"
                     },
@@ -815,69 +810,9 @@
                     },
                     {
                       "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "passages.per_document"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "passages.max_per_document"
-                    },
-                    {
-                      "value": {
-                        "expression": "1"
-                      },
-                      "parameter": "passages.max_answers_per_passage"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "highlight"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "table_results.count"
-                    },
-                    {
-                      "value": {
                         "expression": "false"
                       },
                       "parameter": "table_results.enabled"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "spelling_suggestions"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "suggested_refinements.count"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"\""
-                      },
-                      "parameter": "suggested_refinements.enabled"
-                    },
-                    {
-                      "value": {
-                        "expression": "[\"title\",\"metadata.source.url\"]"
-                      },
-                      "parameter": "return"
-                    },
-                    {
-                      "value": {
-                        "expression": "[\"text\"]"
-                      },
-                      "parameter": "passages.fields"
                     },
                     {
                       "value": {
@@ -892,12 +827,6 @@
                         "skill_variable": "discovery_project_id"
                       },
                       "parameter": "project_id"
-                    },
-                    {
-                      "value": {
-                        "skill_variable": "discovery_instance_id"
-                      },
-                      "parameter": "instance_id"
                     }
                   ],
                   "query": [
@@ -1667,21 +1596,12 @@
         }
       },
       {
-        "title": "discovery_instance_id",
-        "variable": "discovery_instance_id",
-        "data_type": "string",
-        "description": "",
-        "initial_value": {
-          "scalar": "447fc929-fde9-402e-b73c-03274b8ab0bb"
-        }
-      },
-      {
         "title": "discovery_project_id",
         "variable": "discovery_project_id",
         "data_type": "string",
-        "description": "was aa06acac-6aaf-4e75-87de-f9cad3671be1",
+        "description": "",
         "initial_value": {
-          "scalar": "80618725-d10b-4d7a-b91a-79c031f99eee"
+          "scalar": "6ea2ddb1-aa4a-4878-a5c8-247459d22f27"
         }
       },
       {
@@ -1742,22 +1662,7 @@
       "nlp": {
         "model": "latest"
       },
-      "off_topic": {
-        "enabled": true
-      },
       "launch_mode": {},
-      "topic_switch": {
-        "enabled": true,
-        "messages": {
-          "confirm_return": {
-            "text": ""
-          },
-          "confirm_switch": {
-            "text": ""
-          }
-        },
-        "question_steps_threshold": 2
-      },
       "disambiguation": {
         "prompt": "Did you mean:",
         "enabled": false,
@@ -1774,8 +1679,8 @@
     "learning_opt_out": false
   },
   "description": "created for assistant 20ef065f-6198-4892-860a-a184e52a2d19",
-  "assistant_id": "a88c8602-a8c4-4a28-97fb-9d7a16a9b710",
-  "workspace_id": "895e855a-ca58-4ef0-a7f6-229c6341884d",
+  "assistant_id": "7ca897ba-ac3d-45ac-9fe3-5c86a59df89d",
+  "workspace_id": "b9bded36-8ca5-4e17-8a87-4f26e004e229",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }

--- a/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-actions-with-examples.json
+++ b/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-actions-with-examples.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2022-10-05T17:44:18.339Z",
-  "updated": "2022-10-05T18:39:42.172Z",
+  "created": "2023-03-08T18:32:52.647Z",
+  "updated": "2023-03-08T20:53:00.015Z",
   "language": "en",
-  "skill_id": "f0d9a99d-b09b-49a7-a3de-01aef17d6797",
+  "skill_id": "b9bded36-8ca5-4e17-8a87-4f26e004e229",
   "workspace": {
     "actions": [
       {
@@ -762,13 +762,7 @@
           {
             "step": "step_418",
             "output": {
-              "generic": [
-                {
-                  "values": [],
-                  "response_type": "text",
-                  "selection_policy": "sequential"
-                }
-              ]
+              "generic": []
             },
             "context": {
               "variables": [
@@ -825,11 +819,12 @@
             "resolver": {
               "type": "callout",
               "callout": {
-                "path": "/instances/{instance_id}/v2/projects/{project_id}/query",
+                "path": "/v2/projects/{project_id}/query",
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "catalog_item_id": "0b51bf7a-810a-4296-9fd4-c96010f41d66"
+                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
+                  "catalog_item_id": "ca62ae92-447b-44a4-af23-3a239ae8eb2f"
                 },
                 "request_mapping": {
                   "body": [
@@ -838,12 +833,6 @@
                         "expression": "3"
                       },
                       "parameter": "count"
-                    },
-                    {
-                      "value": {
-                        "expression": "\"title:mining\""
-                      },
-                      "parameter": "filter"
                     },
                     {
                       "value": {
@@ -886,6 +875,12 @@
                         "skill_variable": "query_text"
                       },
                       "parameter": "natural_language_query"
+                    },
+                    {
+                      "value": {
+                        "expression": "\"mining\""
+                      },
+                      "parameter": "filter"
                     }
                   ],
                   "path": [
@@ -894,12 +889,6 @@
                         "skill_variable": "discovery_project_id"
                       },
                       "parameter": "project_id"
-                    },
-                    {
-                      "value": {
-                        "skill_variable": "discovery_instance_id"
-                      },
-                      "parameter": "instance_id"
                     }
                   ],
                   "query": [
@@ -1094,7 +1083,7 @@
             "data_type": "any"
           },
           {
-            "title": "No response",
+            "title": "",
             "variable": "step_418",
             "data_type": "any"
           },
@@ -1173,13 +1162,7 @@
           {
             "step": "step_474",
             "output": {
-              "generic": [
-                {
-                  "values": [],
-                  "response_type": "text",
-                  "selection_policy": "sequential"
-                }
-              ]
+              "generic": []
             },
             "context": {
               "variables": [
@@ -1195,17 +1178,18 @@
             "resolver": {
               "type": "callout",
               "callout": {
-                "path": "/instances/{instance_id}/v2/projects/{project_id}/query",
+                "path": "/v2/projects/{project_id}/query",
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "catalog_item_id": "0b51bf7a-810a-4296-9fd4-c96010f41d66"
+                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
+                  "catalog_item_id": "ca62ae92-447b-44a4-af23-3a239ae8eb2f"
                 },
                 "request_mapping": {
                   "body": [
                     {
                       "value": {
-                        "expression": "3"
+                        "expression": "1"
                       },
                       "parameter": "count"
                     },
@@ -1220,12 +1204,6 @@
                         "expression": "[\"title\",\"metadata.source.url\"]"
                       },
                       "parameter": "return"
-                    },
-                    {
-                      "value": {
-                        "expression": "1"
-                      },
-                      "parameter": "passages.count"
                     },
                     {
                       "value": {
@@ -1253,6 +1231,12 @@
                     },
                     {
                       "value": {
+                        "expression": "false"
+                      },
+                      "parameter": "table_results.enabled"
+                    },
+                    {
+                      "value": {
                         "skill_variable": "query_text"
                       },
                       "parameter": "natural_language_query"
@@ -1264,12 +1248,6 @@
                         "skill_variable": "discovery_project_id"
                       },
                       "parameter": "project_id"
-                    },
-                    {
-                      "value": {
-                        "skill_variable": "discovery_instance_id"
-                      },
-                      "parameter": "instance_id"
                     }
                   ],
                   "query": [
@@ -1463,7 +1441,7 @@
             "data_type": "any"
           },
           {
-            "title": "No response",
+            "title": "",
             "variable": "step_474",
             "data_type": "any"
           },
@@ -1651,11 +1629,12 @@
             "resolver": {
               "type": "callout",
               "callout": {
-                "path": "/instances/{instance_id}/v2/projects/{project_id}/query",
+                "path": "/v2/projects/{project_id}/query",
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "catalog_item_id": "0b51bf7a-810a-4296-9fd4-c96010f41d66"
+                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
+                  "catalog_item_id": "ca62ae92-447b-44a4-af23-3a239ae8eb2f"
                 },
                 "request_mapping": {
                   "body": [
@@ -1664,6 +1643,12 @@
                         "expression": "3"
                       },
                       "parameter": "count"
+                    },
+                    {
+                      "value": {
+                        "expression": "[\"title\",\"metadata.source.url\"]"
+                      },
+                      "parameter": "return"
                     },
                     {
                       "value": {
@@ -1691,12 +1676,6 @@
                     },
                     {
                       "value": {
-                        "expression": "[\"title\",\"metadata.source.url\"]"
-                      },
-                      "parameter": "return"
-                    },
-                    {
-                      "value": {
                         "expression": "false"
                       },
                       "parameter": "table_results.enabled"
@@ -1714,12 +1693,6 @@
                         "skill_variable": "discovery_project_id"
                       },
                       "parameter": "project_id"
-                    },
-                    {
-                      "value": {
-                        "skill_variable": "discovery_instance_id"
-                      },
-                      "parameter": "instance_id"
                     }
                   ],
                   "query": [
@@ -2662,24 +2635,9 @@
     "counterexamples": [],
     "system_settings": {
       "nlp": {
-        "model": "baseline"
-      },
-      "off_topic": {
-        "enabled": true
+        "model": "latest"
       },
       "launch_mode": {},
-      "topic_switch": {
-        "enabled": true,
-        "messages": {
-          "confirm_return": {
-            "text": ""
-          },
-          "confirm_switch": {
-            "text": ""
-          }
-        },
-        "question_steps_threshold": 2
-      },
       "disambiguation": {
         "prompt": "Did you mean:",
         "enabled": false,
@@ -2696,8 +2654,8 @@
     "learning_opt_out": false
   },
   "description": "created for assistant 20ef065f-6198-4892-860a-a184e52a2d19",
-  "assistant_id": "594e8f32-e778-4a6f-bdc0-5a4c57224dfd",
-  "workspace_id": "f0d9a99d-b09b-49a7-a3de-01aef17d6797",
+  "assistant_id": "7ca897ba-ac3d-45ac-9fe3-5c86a59df89d",
+  "workspace_id": "b9bded36-8ca5-4e17-8a87-4f26e004e229",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }

--- a/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-openapi.json
+++ b/integrations/extensions/starter-kits/watson-discovery/watson-discovery-query-openapi.json
@@ -3,31 +3,24 @@
   "info": {
     "title": "IBM Watson Discovery query endpoint",
     "description": "IBM Watson Discovery simplified API spec for querying.  You can also download the full spec for the entire service by going to https://cloud.ibm.com/apidocs/discovery-data and clicking on the menu in the upper right.",
-    "version": "1.0"
+    "version": "1.1"
   },
   "servers": [
     {
-      "url": "https://api.{subdomain}.discovery.watson.cloud.ibm.com",
-      "description": "Production servers available to customers",
+      "url": "https://{discovery_url}",
+      "description": "The Watson Discovery URL as specfied in the manage/credentials on IBM Cloud or Cloud Pak for Data",
       "variables": {
-        "subdomain": {
-          "default": "us-south",
-          "description": "The region where your instance is located"
-        }
-      }
-    },
-    {
-      "url": "https://api.{subdomain}.discovery.test.watson.cloud.ibm.com",
-      "description": "Test servers for internal IBM use only",
-      "variables": {
-        "subdomain": {
-          "default": "us-south",
-          "description": "The region where your instance is located"
+        "discovery_url": {
+          "default": "api.us-south.discovery.watson.cloud.ibm.com/instances/12345-6789",
+          "description": "The portions of the Watson Discovery URL that follow https://"
         }
       }
     }
   ],
   "security": [
+    {
+      "bearerAuth": []
+    },
     {
       "basicAuth": []
     }
@@ -38,7 +31,7 @@
     "x-release-notes": "https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-release-notes"
   },
   "paths": {
-    "/instances/{instance_id}/v2/projects/{project_id}/query": {
+    "/v2/projects/{project_id}/query": {
       "post": {
         "operationId": "query",
         "summary": "Query a project",
@@ -60,18 +53,6 @@
             "name": "project_id",
             "in": "path",
             "description": "The ID of the project. This information can be found from the *Integrate and Deploy* page in Discovery.",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 255,
-              "pattern": "^[a-zA-Z0-9_-]*$"
-            }
-          },
-          {
-            "name": "instance_id",
-            "in": "path",
-            "description": "The ID of the instance. This information can be found from the *Integrate and Deploy* page in Discovery.",
             "required": true,
             "schema": {
               "type": "string",
@@ -246,6 +227,10 @@
       "basicAuth": {
         "type": "http",
         "scheme": "basic"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
       }
     },
     "parameters": {


### PR DESCRIPTION
Adds support for CPD in WD BYOS by doing the following:

1. Add a bearer token authentication mechanism to the OpenAPI spec.
2. Modify the server portion of the specification to stop assuming a public cloud server.  Instead, have the user copy the full URL from the credentials page (except for the `http://` at the start, because WA won't allow that part to be inside a variable).
3. Because the full URL includes the instance ID, the instance ID is no longer considered a parameter of the endpoint in the specification and no longer present as a context variable in the actions file.
   - For example, before we would split up `https://api.us-south.discovery.watson.cloud.ibm.com/instances/447fc929-fde9-402e-b73c-03274b8ab0bb/v2/projects/80618725-d10b-4d7a-b91a-79c031f99eee/query` as a server `https://api.us-south.discovery.watson.cloud.ibm.com` and the rest would be part of the API call.
   - Now we would call `https://api.us-south.discovery.watson.cloud.ibm.com/instances/447fc929-fde9-402e-b73c-03274b8ab0bb/` the server.  This is needed to have a common API with CPD because CPD WD structures their URLs differently.
4. Remove settings from the actions files that don't work on CPD.
5. Update the documentation accordingly.