### PR TITLE
fix(watsonx generic starter kit): make use of API key instead of bearer token(which expires in 60 mins & needs a renewal)

### DIFF
--- a/integrations/extensions/starter-kits/language-model-watsonx/README.md
+++ b/integrations/extensions/starter-kits/language-model-watsonx/README.md
@@ -14,7 +14,7 @@ The watsonx specification in the starter kit describes one endpoint, and a few o
 
 ### Create an API key and a project id
 
-1. Log into [watsonx](https://dataplatform.cloud.ibm.com/wx/home?context=wx&apps=cos&nocache=true&onboarding=true&quick_start_target=watsonx) and [generate an API key](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-authentication.html?context=cpdaas). Save this API key somewhere safe and accessible. The initial version of this starter kit uses temporary access tokens only, so you need to [use your API key to authenticate with an IAM token](https://cloud.ibm.com/docs/account?topic=account-iamtoken_from_apikey), which you will need to refresh periodically.
+1. Log into [watsonx](https://dataplatform.cloud.ibm.com/wx/home?context=wx&apps=cos&nocache=true&onboarding=true&quick_start_target=watsonx) and [generate an API key](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-authentication.html?context=cpdaas). Save this API key somewhere safe and accessible. You will need this API key to setup watsonx custom extension later.
 1. To find your watsonx project id, navigate to [your projects](https://dataplatform.cloud.ibm.com/projects/). Open the project you would like to work in, and go to the Manage tab and the Services and integrations tab. Click Associate service + and associate an instance of Watson Machine Learning (WML).
    If you do not have an instance of WML, you can provision a Lite instance from the [IBM Cloud catalog](https://cloud.ibm.com/catalog/services/watson-machine-learning). Then complete this step using the new Lite instance.
 
@@ -40,7 +40,7 @@ You use this specification file to create and add the extension to your assistan
 
 1.  After you build the watsonx extension and it appears on your **Integrations** page, click **Add** to add it to your assistant. For general instructions on adding any custom extension, see [Adding an extension to your assistant](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-add-custom-extension).
 
-1.  In **Authentication**, choose **Bearer auth**. Copy and paste your [authenticated watsonx IAM access token](#create-an-api-key-and-a-project-id) into the **Token** field.
+1.  In **Authentication**, choose **OAuth 2.0**. Make sure grant type is **Custom apikey** selected in the next dropdown. Now copy and paste your [API key](#create-an-api-key-and-a-project-id) you saved earlier into the **Apikey** field.
 
 If you need any capabilities that are not in the watsonx specification that we provided, feel free to add them to the watsonx openapi specification. The specification in the kit is intended to be a simple example of how to get started, not a comprehensive encoding of everything that API can do.
 

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
@@ -1,12 +1,12 @@
 {
-  "name": "watsonx extension sample actions",
+  "name": "watsonx-action",
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2023-07-18T13:36:37.767Z",
-  "updated": "2023-07-18T21:22:48.224Z",
+  "created": "2023-07-20T00:32:11.686Z",
+  "updated": "2023-07-20T01:04:34.155Z",
   "language": "en",
-  "skill_id": "9c3433c1-f60d-4f0a-9648-9b43a23100de",
+  "skill_id": "c1add3e6-11d6-4107-951c-6534a658985a",
   "workspace": {
     "actions": [
       {
@@ -475,8 +475,8 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "f22a973be9c24f524794f9f86d114b5fe9e4e1168ae47ea950e4d7889e972125",
-                  "catalog_item_id": "3a1fabde-51ff-42cc-ad27-23b965370021"
+                  "spec_hash_id": "2933fc3422daaf175981a809c3d29f317259000e45ab18a79783f4ef00285d46",
+                  "catalog_item_id": "0f5d2a32-34f0-4a45-bb6c-38870cb250ca"
                 },
                 "request_mapping": {
                   "body": [
@@ -1189,12 +1189,19 @@
           {
             "type": "synonyms",
             "value": "google/flan-t5-xxl",
-            "synonyms": ["flan-t5-xxl", "t5", "xxl"]
+            "synonyms": [
+              "flan-t5-xxl",
+              "t5",
+              "xxl"
+            ]
           },
           {
             "type": "synonyms",
             "value": "google/flan-ul2",
-            "synonyms": ["flan-ul2", "ul2"]
+            "synonyms": [
+              "flan-ul2",
+              "ul2"
+            ]
           }
         ],
         "fuzzy_match": true
@@ -1380,8 +1387,8 @@
     "learning_opt_out": true
   },
   "description": "created for assistant 05c10d7d-336f-4d33-8cb3-5c53520d61ce",
-  "assistant_id": "3b229721-63a8-4e2e-8aa1-380654a5cdb0",
-  "workspace_id": "9c3433c1-f60d-4f0a-9648-9b43a23100de",
+  "assistant_id": "af1b593b-6ff2-4ee2-8190-099bd47dbf87",
+  "workspace_id": "c1add3e6-11d6-4107-951c-6534a658985a",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
@@ -1,5 +1,5 @@
 {
-  "name": "watsonx-action",
+  "name": "watsonx extension sample actions",
   "type": "action",
   "valid": true,
   "status": "Available",
@@ -1189,19 +1189,12 @@
           {
             "type": "synonyms",
             "value": "google/flan-t5-xxl",
-            "synonyms": [
-              "flan-t5-xxl",
-              "t5",
-              "xxl"
-            ]
+            "synonyms": ["flan-t5-xxl", "t5", "xxl"]
           },
           {
             "type": "synonyms",
             "value": "google/flan-ul2",
-            "synonyms": [
-              "flan-ul2",
-              "ul2"
-            ]
+            "synonyms": ["flan-ul2", "ul2"]
           }
         ],
         "fuzzy_match": true

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "description": "Minimal spec for commonly used features in watsonx.ai /generation API endpoint.  Missing lots of parameters.",
-    "title": "Simplified watsonx.ai generation API",
+    "description": "Minimal spec for commonly used features in watsonx.ai /generattion API endpoint.  Missing lots of parameters.  See https://bam.res.ibm.com/docs/api-reference for details.",
+    "title": "Simplified watsonx.ai generate API",
     "version": "1.0.0"
   },
   "servers": [
@@ -13,16 +13,23 @@
   ],
   "components": {
     "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "x-apikey": {
+            "tokenUrl": "https://iam.cloud.ibm.com/identity/token",
+            "grantType": "urn:ibm:params:oauth:grant-type:apikey",
+            "secretKeys": ["apikey"],
+            "paramKeys": [],
+            "scopes": {}
+          }
+        }
       }
     }
   },
   "security": [
     {
-      "bearerAuth": []
+      "oauth2": []
     }
   ],
   "paths": {
@@ -49,7 +56,7 @@
                 "properties": {
                   "model_id": {
                     "type": "string",
-                    "description": "The ID of the model to be used for this request. Please refer to the list of models at https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-prompt-lab.html?context=wx",
+                    "description": "The ID of the model to be used for this request. Please refer to the list of models at https://bam.res.ibm.com/docs/models",
                     "example": "google/flan-ul2"
                   },
                   "input": {
@@ -93,11 +100,11 @@
                   "type": "object",
                   "properties": {
                     "model_id": {
-                      "description": "The ID of the model to be used for this request",
-                      "type": "string"
+                      "description": "The ID of the model to be used for this request. Please refer to the list of models at https://bam.res.ibm.com/docs/models",
+                      "type": "boolean"
                     },
                     "created_at": {
-                      "description": "The date and time of the response",
+                      "description": "The date and time of the r",
                       "type": "string"
                     },
                     "results": {

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "description": "Minimal spec for commonly used features in watsonx.ai /generattion API endpoint.  Missing lots of parameters.  See https://bam.res.ibm.com/docs/api-reference for details.",
-    "title": "Simplified watsonx.ai generate API",
+    "description": "Minimal spec for commonly used features in watsonx.ai /generation API endpoint.  Missing lots of parameters.  See https://bam.res.ibm.com/docs/api-reference for details.",
+    "title": "Simplified watsonx.ai generation API",
     "version": "1.0.0"
   },
   "servers": [

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
@@ -83,6 +83,11 @@
                         "type": "number",
                         "description": "The maximum number of new tokens to be generated.",
                         "example": "150"
+                      },
+                      "min_new_tokens": {
+                        "type": "number",
+                        "description": "The minimum number of new tokens to be generated.",
+                        "example": "50"
                       }
                     }
                   }


### PR DESCRIPTION
What is included in this PR? 

- Update to openAPI spec file which makes use of OAuth2 custom flow auth type instead of existing bearer token which expires in 60 mins
- Updated actions.json file to match with the new openAPI spec hash
- Readme file changes to list new instructions for using auth. 