### PR TITLE
fix(watsonx generic starter kit): make use of API key instead of bearer token(which expires in 60 mins & needs a renewal)

### DIFF
--- a/integrations/extensions/starter-kits/language-model-watsonx/README.md
+++ b/integrations/extensions/starter-kits/language-model-watsonx/README.md
@@ -14,7 +14,7 @@ The watsonx specification in the starter kit describes one endpoint, and a few o
 
 ### Create an API key and a project id
 
-1. Log into [watsonx](https://dataplatform.cloud.ibm.com/wx/home?context=wx&apps=cos&nocache=true&onboarding=true&quick_start_target=watsonx) and [generate an API key](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-authentication.html?context=cpdaas). Save this API key somewhere safe and accessible. The initial version of this starter kit uses temporary access tokens only, so you need to [use your API key to authenticate with an IAM token](https://cloud.ibm.com/docs/account?topic=account-iamtoken_from_apikey), which you will need to refresh periodically.
+1. Log into [watsonx](https://dataplatform.cloud.ibm.com/wx/home?context=wx&apps=cos&nocache=true&onboarding=true&quick_start_target=watsonx) and [generate an API key](https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/ml-authentication.html?context=cpdaas). Save this API key somewhere safe and accessible. You will need this API key to setup watsonx custom extension later.
 1. To find your watsonx project id, navigate to [your projects](https://dataplatform.cloud.ibm.com/projects/). Open the project you would like to work in, and go to the Manage tab and the Services and integrations tab. Click Associate service + and associate an instance of Watson Machine Learning (WML).
    If you do not have an instance of WML, you can provision a Lite instance from the [IBM Cloud catalog](https://cloud.ibm.com/catalog/services/watson-machine-learning). Then complete this step using the new Lite instance.
 
@@ -40,7 +40,7 @@ You use this specification file to create and add the extension to your assistan
 
 1.  After you build the watsonx extension and it appears on your **Integrations** page, click **Add** to add it to your assistant. For general instructions on adding any custom extension, see [Adding an extension to your assistant](https://cloud.ibm.com/docs/watson-assistant?topic=watson-assistant-add-custom-extension).
 
-1.  In **Authentication**, choose **Bearer auth**. Copy and paste your [authenticated watsonx IAM access token](#create-an-api-key-and-a-project-id) into the **Token** field.
+1.  In **Authentication**, choose **OAuth 2.0**. Make sure grant type is **Custom apikey** selected in the next dropdown. Now copy and paste your [API key](#create-an-api-key-and-a-project-id) you saved earlier into the **Apikey** field.
 
 If you need any capabilities that are not in the watsonx specification that we provided, feel free to add them to the watsonx openapi specification. The specification in the kit is intended to be a simple example of how to get started, not a comprehensive encoding of everything that API can do.
 

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2023-07-21T23:27:18.637Z",
-  "updated": "2023-07-21T23:31:17.833Z",
+  "created": "2023-07-22T15:27:13.429Z",
+  "updated": "2023-07-22T15:31:15.239Z",
   "language": "en",
-  "skill_id": "096d12a9-3b20-43ac-bc18-9d2e4c79ec1a",
+  "skill_id": "bb764987-8d04-4709-8c35-0561fedf105c",
   "workspace": {
     "actions": [
       {
@@ -629,8 +629,8 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "efd13c68dff079388ffa62bfc3aff447e49efd7024450961cc74d6de89106cce",
-                  "catalog_item_id": "f53a6acc-4505-45a5-a785-27fe357b96da"
+                  "spec_hash_id": "572393bac5639f3adad43d3d7cc830fc3575568d094fa2bb634d33e62f83f0a5",
+                  "catalog_item_id": "4b26b235-5e05-4182-8cc7-728ba85d7d3e"
                 },
                 "request_mapping": {
                   "body": [
@@ -1580,8 +1580,8 @@
     "learning_opt_out": true
   },
   "description": "created for assistant 05c10d7d-336f-4d33-8cb3-5c53520d61ce",
-  "assistant_id": "69f5847f-17c6-4cb0-bafe-e1c3e5f7cfd2",
-  "workspace_id": "096d12a9-3b20-43ac-bc18-9d2e4c79ec1a",
+  "assistant_id": "b2b9dc09-1d15-4514-9a4d-9636cf3afd44",
+  "workspace_id": "bb764987-8d04-4709-8c35-0561fedf105c",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2023-07-22T15:27:13.429Z",
-  "updated": "2023-07-22T15:31:15.239Z",
+  "created": "2023-07-26T00:29:57.573Z",
+  "updated": "2023-07-26T00:34:33.767Z",
   "language": "en",
-  "skill_id": "bb764987-8d04-4709-8c35-0561fedf105c",
+  "skill_id": "d7b6684e-45f0-4fed-967e-c1091494f945",
   "workspace": {
     "actions": [
       {
@@ -629,8 +629,8 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "572393bac5639f3adad43d3d7cc830fc3575568d094fa2bb634d33e62f83f0a5",
-                  "catalog_item_id": "4b26b235-5e05-4182-8cc7-728ba85d7d3e"
+                  "spec_hash_id": "cc50493e455de183d661b95360196ddb468a02051add6dcaf4a6479b34900be5",
+                  "catalog_item_id": "4f170e0d-95b5-4f59-9d1d-e52f67ee9352"
                 },
                 "request_mapping": {
                   "body": [
@@ -1580,8 +1580,8 @@
     "learning_opt_out": true
   },
   "description": "created for assistant 05c10d7d-336f-4d33-8cb3-5c53520d61ce",
-  "assistant_id": "b2b9dc09-1d15-4514-9a4d-9636cf3afd44",
-  "workspace_id": "bb764987-8d04-4709-8c35-0561fedf105c",
+  "assistant_id": "67614f79-ba73-4c10-a90f-9b647f797521",
+  "workspace_id": "d7b6684e-45f0-4fed-967e-c1091494f945",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "description": "Minimal spec for commonly used features in watsonx.ai /generation API endpoint.  Missing a few of parameters.",
+    "description": "Minimal spec for commonly used features in watsonx.ai /generation API endpoint. Missing a few of parameters.",
     "title": "Simplified watsonx.ai generation API",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "servers": [
     {
@@ -13,16 +13,23 @@
   ],
   "components": {
     "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "JWT"
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "x-apikey": {
+            "tokenUrl": "https://iam.cloud.ibm.com/identity/token",
+            "grantType": "urn:ibm:params:oauth:grant-type:apikey",
+            "secretKeys": ["apikey"],
+            "paramKeys": [],
+            "scopes": {}
+          }
+        }
       }
     }
   },
   "security": [
     {
-      "bearerAuth": []
+      "oauth2": []
     }
   ],
   "paths": {


### PR DESCRIPTION
What is included in this PR? 

- Update to openAPI spec file which makes use of OAuth2 custom flow auth type instead of existing bearer token which expires in 60 mins
- Updated actions.json file to match with the new openAPI spec hash
- Readme file changes to list new instructions for using auth. 