### PR TITLE
fix: missing param passages.per_document

### DIFF
--- a/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2023-07-24T14:34:28.109Z",
-  "updated": "2023-07-25T05:18:44.642Z",
+  "created": "2023-08-08T14:50:37.686Z",
+  "updated": "2023-08-08T14:57:09.297Z",
   "language": "en",
-  "skill_id": "b9406366-1512-4553-ae35-60ba0ebe0bb9",
+  "skill_id": "d283483b-e2ff-4ed9-9134-f2ef57ef0f28",
   "workspace": {
     "actions": [
       {
@@ -495,7 +495,7 @@
                 "method": "POST",
                 "internal": {
                   "spec_hash_id": "cc50493e455de183d661b95360196ddb468a02051add6dcaf4a6479b34900be5",
-                  "catalog_item_id": "f6a34340-796b-4d64-8186-06f61391e61e"
+                  "catalog_item_id": "e210b2f1-9015-47b0-8a45-1a68611d6448"
                 },
                 "request_mapping": {
                   "body": [
@@ -798,7 +798,7 @@
                 "method": "POST",
                 "internal": {
                   "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
-                  "catalog_item_id": "39268001-1084-4b65-ac57-7fd9fd1e67e5"
+                  "catalog_item_id": "8fd0494f-37ea-48d7-9582-1ace2fc0c45a"
                 },
                 "request_mapping": {
                   "body": [
@@ -849,6 +849,12 @@
                         "skill_variable": "query_text"
                       },
                       "parameter": "natural_language_query"
+                    },
+                    {
+                      "value": {
+                        "scalar": true
+                      },
+                      "parameter": "passages.per_document"
                     }
                   ],
                   "path": [
@@ -1964,8 +1970,8 @@
     "learning_opt_out": true
   },
   "description": "created for assistant 1c76effb-2430-4334-8897-6cdad3c6282b",
-  "assistant_id": "1e6040e4-c997-4ef9-a16f-b101bdbef59f",
-  "workspace_id": "b9406366-1512-4553-ae35-60ba0ebe0bb9",
+  "assistant_id": "a1109da6-1e19-46b5-9586-478484eab96a",
+  "workspace_id": "d283483b-e2ff-4ed9-9134-f2ef57ef0f28",
   "dialog_settings": {},
   "next_snapshot_version": "1"
 }


### PR DESCRIPTION
In the starter kit, we are missing `document_per_passage` default true, which is causing some issues getting back expected results from the discovery. This fixes it. 