### PR TITLE
feat(testitall): Update the test starter-kit

### DIFF
--- a/integrations/extensions/starter-kits/testitall/mock-server/Dockerfile
+++ b/integrations/extensions/starter-kits/testitall/mock-server/Dockerfile
@@ -10,8 +10,6 @@ RUN npm install --only=production
 
 # Bundle app source
 COPY . .
-# Copy .env-sample to .env
-COPY .env-sample .env
 
 EXPOSE 4000
 

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/auth-code.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/auth-code.js
@@ -8,7 +8,7 @@ function issueAccessToken() {
   const accessToken = Math.random().toString(36).slice(-8)
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensAuthCode.set(accessToken, accessExpireTime)
-  console.log('[auth code] Issuing token:', accessToken)
+  console.log(`[auth code] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)
 
   return accessToken
 }

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/client-cred.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/client-cred.js
@@ -8,7 +8,7 @@ function issueAccessToken() {
   const accessToken = Math.random().toString(36).slice(-8)
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensClientCred.set(accessToken, accessExpireTime)
-  console.log('[client cred] Issuing token:', accessToken)
+  console.log(`[client cred] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)
 
   return accessToken
 }

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/custom-apikey.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/custom-apikey.js
@@ -10,7 +10,7 @@ function issueAccessToken() {
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensCustomApikey.set(accessToken, accessExpireTime)
 
-  console.log('[custom apikey] Issuing token:', accessToken)
+  console.log(`[custom apikey] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)
   return accessToken
 }
 

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/password.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/password.js
@@ -6,7 +6,7 @@ function issueAccessToken() {
   const accessToken = Math.random().toString(36).slice(-8)
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensPassword.set(accessToken, accessExpireTime)
-  console.log('[password] Issuing token:', accessToken)
+  console.log(`[password] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)
 
   return accessToken
 }

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/test-controller.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/test-controller.js
@@ -32,6 +32,12 @@ export function postTest(req, res) {
   }
 }
 
+export function patchTest(req, res) {
+  return res.json({
+    status: 'PATCHED',
+  });
+}
+
 export function authHeaderTest(req, res) {
   return res.json({
     auth_header: req.header('Authorization') || 'No Authorization header provided',
@@ -59,7 +65,7 @@ export function errorTest(req, res) {
 
 
 export function contextTooLargeTest(req, res) {
-  const fakeData = 'x'.repeat(parseInt(process.env.RESPONSE_SIZE_LIMIT, 10) * 5); // Default: 500KB
+  const fakeData = 'x'.repeat(parseInt(process.env.RESPONSE_SIZE_LIMIT, 10) * 5); // Default: 130KB * 5 = 650KB
   const response = {
     data: fakeData
   }
@@ -68,7 +74,7 @@ export function contextTooLargeTest(req, res) {
 }
 
 export function contextAlmostTooLargeTest(req, res) {
-  const fakeData = 'x'.repeat(parseInt(process.env.RESPONSE_SIZE_LIMIT, 10) - 1024); // Default: 99KB
+  const fakeData = 'x'.repeat(parseInt(process.env.RESPONSE_SIZE_LIMIT, 10) - 1024); // Default: 130KB - 1KB = 129KB
 
   const response = {
     data: fakeData

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/routes/test-route.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/routes/test-route.js
@@ -9,6 +9,7 @@ router.delete('', testController.deleteTest);
 router.get('', testController.getTest);
 router.put('', testController.putTest);
 router.post('', testController.postTest);
+router.patch('', testController.patchTest);
 router.post('/error', testController.errorTest);
 router.post('/params/:path_param', testController.postTest);
 router.post('/auth_header', testController.authHeaderTest);

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/server.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/server.js
@@ -23,7 +23,7 @@ const app = express();
 app.use(morgan('dev'));
 
 // enable parsing of http request body
-app.use(bodyParser.urlencoded({extended: false}));
+app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 
 // access to static files

--- a/integrations/extensions/starter-kits/testitall/testitall.actions.json
+++ b/integrations/extensions/starter-kits/testitall/testitall.actions.json
@@ -45,7 +45,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -396,7 +396,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -542,7 +542,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_658_result_1"
@@ -647,7 +647,7 @@
                 "type": "integration_interaction",
                 "method": "PUT",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -783,7 +783,7 @@
                 "type": "integration_interaction",
                 "method": "GET",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_628_result_1"
@@ -951,7 +951,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -1186,7 +1186,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -1593,7 +1593,7 @@
                 "type": "integration_interaction",
                 "method": "DELETE",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_863_result_1"
@@ -1849,7 +1849,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -2060,7 +2060,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_588_result_1"
@@ -2250,7 +2250,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "request_mapping": {
@@ -2418,7 +2418,7 @@
                 "type": "integration_interaction",
                 "method": "GET",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_646_result_1"
@@ -2463,7 +2463,7 @@
                 "type": "integration_interaction",
                 "method": "GET",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_507_result_1"
@@ -2508,7 +2508,7 @@
                 "type": "integration_interaction",
                 "method": "DELETE",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_154_result_1"
@@ -2630,7 +2630,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "a41be063157fb8d5262a3d76dc51afa0019b60eaecdfa7bed590ff86faf1df8d",
+                  "spec_hash_id": "ace545a0177945ee96ac8df8000db4c500ee0368d5902d6cfe14402baf86b456",
                   "catalog_item_id": "a5af7399-4346-4f6b-b689-24833f6f0dbc"
                 },
                 "result_variable": "step_526_result_1"

--- a/integrations/extensions/starter-kits/testitall/testitall.openapi.json
+++ b/integrations/extensions/starter-kits/testitall/testitall.openapi.json
@@ -8,31 +8,7 @@
   },
   "servers": [
     {
-      "url": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud",
-      "description": "IBM Hosted Mock API Server"
-    },
-    {
-      "url": "https://{ngrok_uuid}.ngrok-free.app",
-      "description": "ngrok free server",
-      "variables": {
-        "ngrok_uuid": {
-          "description": "ngrok domain prefix (uuid)",
-          "default": ""
-        }
-      }
-    },
-    {
-      "url": "https://{ngrok_uuid}.ngrok.io",
-      "description": "ngrok server",
-      "variables": {
-        "ngrok_uuid": {
-          "description": "ngrok domain prefix (uuid)",
-          "default": ""
-        }
-      }
-    },
-    {
-      "url": "http://{host}:{port}",
+      "url": "https://{host}:{port}",
       "description": "Your API server",
       "variables": {
         "host": {
@@ -40,7 +16,7 @@
           "description": "Hostname of the API server"
         },
         "port": {
-          "default": "4000",
+          "default": "443",
           "description": "Port of the API server"
         }
       }
@@ -48,50 +24,50 @@
   ],
   "components": {
     "securitySchemes": {
-      "BasicAuth": {
+      "basic": {
         "type": "http",
         "scheme": "basic"
       },
-      "BearerAuth": {
+      "bearer": {
         "type": "http",
         "scheme": "bearer"
       },
-      "ApiKeyAuth": {
+      "api_key": {
         "type": "apiKey",
         "in": "header",
         "name": "X-API-Key"
       },
-      "OAuth2": {
+      "oauth2": {
         "type": "oauth2",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/auth-code/authorize",
-            "tokenUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/auth-code/token",
-            "refreshUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/auth-code/token",
+            "authorizationUrl": "/oauth2-provider/auth-code/authorize",
+            "tokenUrl": "/oauth2-provider/auth-code/token",
+            "refreshUrl": "/oauth2-provider/auth-code/token",
             "scopes": {
               "read": "Read access to protected resources",
               "custom": "Add your own scope"
             }
           },
           "password": {
-            "tokenUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/password/token",
-            "refreshUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/password/token",
+            "tokenUrl": "/oauth2-provider/password/token",
+            "refreshUrl": "/oauth2-provider/password/token",
             "scopes": {
               "read": "Read access to protected resources",
               "custom": "Add your own scope"
             }
           },
           "clientCredentials": {
-            "tokenUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/client-cred/token",
-            "refreshUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/client-cred/token",
+            "tokenUrl": "/oauth2-provider/client-cred/token",
+            "refreshUrl": "/oauth2-provider/client-cred/token",
             "scopes": {
               "read": "Read access to protected resources",
               "custom": "Add your own scope"
             }
           },
           "x-apikey": {
-            "tokenUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/custom-apikey/token",
-            "refreshUrl": "https://custom-ext-testitall-ce.vkgqdtxxpfe.us-south.codeengine.appdomain.cloud/oauth2-provider/custom-apikey/token",
+            "tokenUrl": "/oauth2-provider/custom-apikey/token",
+            "refreshUrl": "/oauth2-provider/custom-apikey/token",
             "grantType": "custom_apikey",
             "secretKeys": [
               "apikey_secret"
@@ -107,16 +83,16 @@
   },
   "security": [
     {
-      "BasicAuth": []
+      "basic": []
     },
     {
-      "BearerAuth": []
+      "bearer": []
     },
     {
-      "ApiKeyAuth": []
+      "api_key": []
     },
     {
-      "OAuth2": [
+      "oauth2": [
         "read",
         "custom"
       ]
@@ -299,6 +275,31 @@
         "responses": {
           "200": {
             "description": "DELETE response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "API"
+        ],
+        "summary": "Test HTTP PATCH",
+        "description": "TEST PATCH",
+        "operationId": "testPatch",
+        "responses": {
+          "200": {
+            "description": "PATCH response",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
- Update OpenAPI spec to use relative URL
- Remove hosted server info
- Update Mock server to support patch test
- Update `AlmostTooLarge` context test limit to 130KB
- Renamed `securitySchemes` in OpenAPI spec to v2 standard