### PR TITLE
fix: fix the starter kit issue caused by knn

### DIFF
--- a/integrations/extensions/docs/elasticsearch-install-and-setup/README.md
+++ b/integrations/extensions/docs/elasticsearch-install-and-setup/README.md
@@ -31,7 +31,7 @@ For semantic search using ELSER v1, please include the following query body in t
 
 <img src="assets/query_body_for_elasticsearch.png" width="547" height="638" />
 
-For ELSER v2 use the following query body instead
+For ELSER v2, use the following query body instead
 ```json
 {
   "query": {
@@ -46,7 +46,7 @@ For ELSER v2 use the following query body instead
 ```
 
 #### b. Dense Vector (KNN) Search
-For dense vector search use the following json object:
+For dense vector search, use the following json object:
 ```json
 {
   "knn": {

--- a/integrations/extensions/starter-kits/elasticsearch/README.md
+++ b/integrations/extensions/starter-kits/elasticsearch/README.md
@@ -65,7 +65,7 @@ but you will need to find set-up instructions appropriate to that environment.
       NOTE: Learn more about ELSER v2 from [here](https://www.elastic.co/guide/en/elasticsearch/reference/8.11/semantic-search-elser.html). 
       ELSER v2 is only available for the 8.11 version of Elasticsearch
 
-    * To use dense vector search (k-nearest neighbours search), you can set `knn_body` as a session variable and set the `knn` variable to `knn_body` as shown below:
+    * To use dense vector search (k-nearest neighbours search), you can set `knn_body` as a session variable and set the `knn` parameter to `knn_body` as shown below:
       
       Here is an example knn body you can use when setting up the `knn_body` session variable:
       

--- a/integrations/extensions/starter-kits/language-model-conversational-search/README.md
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/README.md
@@ -108,7 +108,6 @@ Below is a list of the session variables used in this example. Most of them are 
 - `verbose`: A boolean that will print debugging output if true. Default is false. Note that if you turn this on, you will see the prompt we send to the model.
 - `watsonx_api_version` - watsonx api date version. It currently defaults to `2023-05-29`.
 - `watsonx_project_id`: You **MUST** set this value to be [a project ID value from watsonx](https://dataplatform.cloud.ibm.com/docs/content/wsj/manage-data/manage-projects.html). By default, this is a [sandbox project id](https://dataplatform.cloud.ibm.com/docs/content/wsj/manage-data/sandbox.html) that is automatically created for you when you sign up for watsonx.ai.
-- `use_knn_search`: This is set to `false` by default. You **MUST** set this to `true` if want to use knn search on an embedding index.
 
 NOTE: `query_body` will be used as the value of the query parameter in the request body for the Elasticsearch Search API.
 Depending on the type of search query, you may need to use different forms of `query_body`. You can find some `query_body` examples [here](../elasticsearch/README.md#build-a-custom-extension-in-watsonx-assistant-with-elasticsearch-api).
@@ -147,7 +146,7 @@ a default `knn_body` like below is set to work with the sample data and index us
 ```
 
 
-Make sure you use a text embedding index if using knn search. Please see [here](../../docs/elasticsearch-install-and-setup/text_embedding_deploy_and_use.md) for more information on how to set up and use text embeddings for dense vector search in Elasticsearch. You must also set the `use_knn_search` session variable to `true` when using dense vector search.
+Make sure you use a text embedding index if using knn search. Please see [here](../../docs/elasticsearch-install-and-setup/text_embedding_deploy_and_use.md) for more information on how to set up and use text embeddings for dense vector search in Elasticsearch. You must remove the `query` parameter assignment in the list of optional parameters and only set the `knn` parameter when using dense vector search.
 
 ### Example 1 usage:
 

--- a/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
@@ -3,13 +3,14 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2024-02-28T18:56:12.276Z",
-  "updated": "2024-03-22T15:58:02.356Z",
+  "created": "2024-03-26T21:18:44.256Z",
+  "updated": "2024-04-01T21:26:50.446Z",
   "language": "en",
-  "skill_id": "8ececc72-d8fe-41e7-bc75-4fd73b052406",
+  "skill_id": "701b479c-8e8f-4e9b-beb0-a8275b05b935",
   "workspace": {
     "actions": [
       {
+        "type": "standard",
         "steps": [
           {
             "step": "step_849",
@@ -84,19 +85,19 @@
               "variables": [
                 {
                   "value": {
-                    "expression": "{\n    \"nested\": {\n      \"path\": \"passages\",\n      \"query\": { \n        \"text_expansion\": {\n          \"passages.sparse.tokens\": {\n            \"model_id\": \".elser_model_1\",\n            \"model_text\": ${query_text}\n          }\n        }\n      },\n      \"inner_hits\": {\"_source\": {\"excludes\": [\"passages.sparse\"]}}\n    }\n}"
+                    "expression": "{\n    \"nested\": {\n      \"path\": \"passages\",\n      \"query\": { \n        \"text_expansion\": {\n          \"passages.sparse.tokens\": {\n            \"model_id\": ${es_model},\n            \"model_text\": ${query_text}\n          }\n        }\n      },\n      \"inner_hits\": {\"_source\": {\"excludes\": [\"passages.sparse\"]}}\n    }\n}"
                   },
                   "skill_variable": "query_body_nested"
                 },
                 {
                   "value": {
-                    "expression": "{\n    \"text_expansion\": {\n      \"ml.tokens\": {\n        \"model_id\": $es_model,\n        \"model_text\": ${query_text}\n      }\n    }\n  }"
+                    "expression": "{\n    \"text_expansion\": {\n      \"ml.tokens\": {\n        \"model_id\": ${es_model},\n        \"model_text\": ${query_text}\n      }\n    }\n  }"
                   },
                   "skill_variable": "query_body_generic"
                 },
                 {
                   "value": {
-                    "expression": "${use_knn_search}? \"\":(${has_inner_hits} ? ${query_body_nested} : ${query_body_generic})"
+                    "expression": "${has_inner_hits} ? ${query_body_nested} : ${query_body_generic}"
                   },
                   "skill_variable": "query_body"
                 },
@@ -108,7 +109,7 @@
                 },
                 {
                   "value": {
-                    "expression": "${use_knn_search} ? {\n    \"field\": \"text_embedding.predicted_value\",\n    \"query_vector_builder\": {\n      \"text_embedding\": {\n        \"model_id\": $embedding_model,\n        \"model_text\": ${query_text}\n      }\n    },\n    \"k\": 10,\n    \"num_candidates\": 100\n  }: \"\""
+                    "expression": "{\n    \"field\": \"text_embedding.predicted_value\",\n    \"query_vector_builder\": {\n      \"text_embedding\": {\n        \"model_id\": ${embedding_model},\n        \"model_text\": ${query_text}\n      }\n    },\n    \"k\": 10,\n    \"num_candidates\": 100\n  }"
                   },
                   "skill_variable": "knn_body"
                 }
@@ -123,7 +124,7 @@
                 "method": "POST",
                 "internal": {
                   "spec_hash_id": "0988f31a617dc5ff6b276fdc3be98135801830c3ceeac02a58846426fe81c974",
-                  "catalog_item_id": "dc113e1e-dadd-4dc1-8c90-ded2f8741ef1"
+                  "catalog_item_id": "ef58aa6f-c936-4270-afaf-0af6f20ed2aa"
                 },
                 "request_mapping": {
                   "body": [
@@ -144,12 +145,6 @@
                         "skill_variable": "query_source"
                       },
                       "parameter": "_source"
-                    },
-                    {
-                      "value": {
-                        "skill_variable": "knn_body"
-                      },
-                      "parameter": "knn"
                     }
                   ],
                   "path": [
@@ -388,6 +383,7 @@
         "disambiguation_opt_out": false
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "step_291",
@@ -975,6 +971,7 @@
         "disambiguation_opt_out": false
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "step_888",
@@ -990,7 +987,7 @@
                 "method": "POST",
                 "internal": {
                   "spec_hash_id": "540081b16fe217626f2ff197e583c2f1c7ef19f0752c8b875ec454036cfdda7f",
-                  "catalog_item_id": "ca634c4a-453b-4a76-a4f2-991a11d663c5"
+                  "catalog_item_id": "bdddba91-cd6f-449b-959f-31e29f187e1e"
                 },
                 "request_mapping": {
                   "body": [
@@ -1305,6 +1302,7 @@
         "disambiguation_opt_out": false
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "step_195",
@@ -1453,6 +1451,7 @@
         "disambiguation_opt_out": true
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "digression_failure",
@@ -1761,6 +1760,7 @@
         "disambiguation_opt_out": true
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "danger_word_detected",
@@ -1835,6 +1835,7 @@
         "next_action": "anything_else"
       },
       {
+        "type": "standard",
         "steps": [
           {
             "step": "step_001",
@@ -1947,15 +1948,6 @@
         "description": ""
       },
       {
-        "title": "es_index_name",
-        "privacy": {
-          "enabled": false
-        },
-        "variable": "es_index_name",
-        "data_type": "string",
-        "description": "You MUST set this to your Elasticsearch index name."
-      },
-      {
         "title": "embedding_model",
         "privacy": {
           "enabled": false
@@ -1965,6 +1957,18 @@
         "description": "",
         "initial_value": {
           "scalar": "intfloat__multilingual-e5-small"
+        }
+      },
+      {
+        "title": "es_index_name",
+        "privacy": {
+          "enabled": false
+        },
+        "variable": "es_index_name",
+        "data_type": "string",
+        "description": "You MUST set this to your Elasticsearch index name.",
+        "initial_value": {
+          "scalar": "search-wa-docs"
         }
       },
       {
@@ -2223,18 +2227,6 @@
         "description": ""
       },
       {
-        "title": "use_knn_search",
-        "privacy": {
-          "enabled": false
-        },
-        "variable": "use_knn_search",
-        "data_type": "boolean",
-        "description": "",
-        "initial_value": {
-          "scalar": false
-        }
-      },
-      {
         "title": "verbose",
         "privacy": {
           "enabled": false
@@ -2378,9 +2370,9 @@
     "learning_opt_out": true
   },
   "description": "created for assistant fcee95d0-3673-43ea-9349-9e4458738da2",
-  "assistant_id": "f612f5fa-555a-4b6c-b6ef-49495df2229c",
-  "workspace_id": "8ececc72-d8fe-41e7-bc75-4fd73b052406",
+  "assistant_id": "ed0a1bd7-c3a7-43c5-a740-0ab12efec5dc",
+  "workspace_id": "701b479c-8e8f-4e9b-beb0-a8275b05b935",
   "dialog_settings": {},
   "next_snapshot_version": "1",
-  "environment_id": "7c96a36c-53a0-4e14-ae47-b8ce5af48fd1"
+  "environment_id": "398602c7-6959-4863-a973-42e4dcef58c9"
 }

--- a/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
@@ -4,7 +4,7 @@
   "valid": true,
   "status": "Available",
   "created": "2024-03-26T21:18:44.256Z",
-  "updated": "2024-04-01T21:26:50.446Z",
+  "updated": "2024-04-03T20:31:34.685Z",
   "language": "en",
   "skill_id": "701b479c-8e8f-4e9b-beb0-a8275b05b935",
   "workspace": {
@@ -1966,10 +1966,7 @@
         },
         "variable": "es_index_name",
         "data_type": "string",
-        "description": "You MUST set this to your Elasticsearch index name.",
-        "initial_value": {
-          "scalar": "search-wa-docs"
-        }
+        "description": "You MUST set this to your Elasticsearch index name."
       },
       {
         "title": "es_model",


### PR DESCRIPTION
When sending a search query to Elasticsearch, `query` and `knn` parameters cannot be used at the same time unless it is a hybrid search. This PR removes the `knn` parameter assignment in the actions JSON to make the starter kit work out of the box. 

Slack thread: https://ibm-analytics.slack.com/archives/C1U97HQ3T/p1711996051841799?thread_ts=1711755097.522389&cid=C1U97HQ3T