### PR TITLE
feat: support region in the watsonx.ai url

### DIFF
--- a/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
@@ -494,7 +494,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "540081b16fe217626f2ff197e583c2f1c7ef19f0752c8b875ec454036cfdda7f",
+                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
                   "catalog_item_id": "16bf38b2-037f-4f95-87d3-77ad737b3c0f"
                 },
                 "request_mapping": {

--- a/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
@@ -3,10 +3,10 @@
   "type": "action",
   "valid": true,
   "status": "Available",
-  "created": "2024-04-24T17:13:35.121Z",
-  "updated": "2024-04-25T18:44:15.609Z",
+  "created": "2024-02-28T19:44:41.345Z",
+  "updated": "2024-05-22T18:49:03.721Z",
   "language": "en",
-  "skill_id": "7f2b5c5f-f0b1-4566-a27b-c1ef40c85eec",
+  "skill_id": "e48ccc68-7d45-44c4-babb-c9efaf717c2b",
   "workspace": {
     "actions": [
       {
@@ -124,7 +124,8 @@
                 "method": "POST",
                 "internal": {
                   "spec_hash_id": "0988f31a617dc5ff6b276fdc3be98135801830c3ceeac02a58846426fe81c974",
-                  "catalog_item_id": "520efed4-c7f9-41ec-9235-917537b9f7cd"
+                  "match_scenario": 5,
+                  "catalog_item_id": "d3615e2d-2ed1-4a12-b38a-6befaebf6cbb"
                 },
                 "request_mapping": {
                   "body": [
@@ -986,8 +987,9 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "540081b16fe217626f2ff197e583c2f1c7ef19f0752c8b875ec454036cfdda7f",
-                  "catalog_item_id": "17540f61-7e46-464e-9f8d-7ceffb42b7e0"
+                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
+                  "match_scenario": 1,
+                  "catalog_item_id": "c3899a4f-2ba6-4427-8ff3-823a0a5cc7d8"
                 },
                 "request_mapping": {
                   "body": [
@@ -1934,7 +1936,7 @@
     "metadata": {
       "api_version": {
         "major_version": "v2",
-        "minor_version": "2018-11-08"
+        "minor_version": "2021-11-27"
       }
     },
     "variables": [
@@ -2391,9 +2393,9 @@
     "learning_opt_out": true
   },
   "description": "created for assistant fcee95d0-3673-43ea-9349-9e4458738da2",
-  "assistant_id": "e4344152-0ffc-4950-bad2-726f6b06ae5a",
-  "workspace_id": "7f2b5c5f-f0b1-4566-a27b-c1ef40c85eec",
+  "assistant_id": "52d5828a-8dfd-4c59-9c14-00d4b940cac5",
+  "workspace_id": "e48ccc68-7d45-44c4-babb-c9efaf717c2b",
   "dialog_settings": {},
   "next_snapshot_version": "1",
-  "environment_id": "00a9dd4c-82c2-46c0-b69b-280e08dd52ce"
+  "environment_id": "d9d8d7c5-6528-4bee-ab99-c3f9e1a3fee2"
 }

--- a/integrations/extensions/starter-kits/language-model-conversational-search/vector-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/vector-watsonx-actions.json
@@ -467,7 +467,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "540081b16fe217626f2ff197e583c2f1c7ef19f0752c8b875ec454036cfdda7f",
+                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
                   "catalog_item_id": "16bf38b2-037f-4f95-87d3-77ad737b3c0f"
                 },
                 "request_mapping": {

--- a/integrations/extensions/starter-kits/language-model-watsonx/README.md
+++ b/integrations/extensions/starter-kits/language-model-watsonx/README.md
@@ -45,6 +45,8 @@ Use this specification file to create and add the extension to your assistant.
 
 1.  In **Authentication**, choose **OAuth 2.0**. Select **Custom apikey** as the grant type in the next dropdown, and then copy and paste your [API key](#create-an-api-key-and-a-project-id) you saved earlier into the **Apikey** field.
 
+1.  In **Servers**, choose the region from which you would like to access the watsonx.ai service. `us-south` is selected as the default region. 
+
 If you need capabilities that are not in the watsonx specification provided, feel free to add them to the watsonx openapi specification. The specification in the kit is intended to be an example of how to get started, not a comprehensive encoding of everything that the API can do.
 
 ## Upload sample action

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-actions.json
@@ -629,7 +629,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "540081b16fe217626f2ff197e583c2f1c7ef19f0752c8b875ec454036cfdda7f",
+                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
                   "catalog_item_id": "4f170e0d-95b5-4f59-9d1d-e52f67ee9352"
                 },
                 "request_mapping": {

--- a/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
+++ b/integrations/extensions/starter-kits/language-model-watsonx/watsonx-openapi.json
@@ -7,8 +7,20 @@
   },
   "servers": [
     {
-      "url": "https://us-south.ml.cloud.ibm.com",
-      "description": "watsonx.ai v1"
+      "url": "https://{region}.ml.cloud.ibm.com",
+      "description": "watsonx.ai v1",
+      "variables": {
+        "region": {
+          "enum": [
+            "us-south",
+            "eu-de",
+            "eu-gb",
+            "jp-tok"
+          ],
+          "default": "us-south",
+          "description": "The region where you want to access watsonx.ai"
+        }
+      }
     }
   ],
   "components": {
@@ -121,6 +133,9 @@
                       },
                       "stop_sequences": {
                         "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
                         "description": "Stop sequences are one or more strings which will cause the text generation to stop if/when they are produced as part of the output. Stop sequences encountered prior to the minimum number of tokens being generated will be ignored.",
                         "example": ["\n\n"]
                       },


### PR DESCRIPTION
This PR adds a region parameter to the watsonx.ai open API spec to allow specifying the region when constructing the server URL. It also updates all the starter-kit workspace JSON files that use the watsonx.ai service. 

Signed off by: zhongzheng.shu@ibm.com