### PR TITLE
fix(zendesk): Zendesk will soon no longer support password auth - remove instructions

### DIFF
--- a/integrations/extensions/starter-kits/zendesk-support/README.md
+++ b/integrations/extensions/starter-kits/zendesk-support/README.md
@@ -18,8 +18,7 @@ Zendesk requires you to have authentication in order to have fully functioning A
 1. Navigate to the `Admin Center` - i.e. `https://{server-domain}.zendesk.com/admin`
 1. On the left hand menu, go to `Apps and integrations` > `APIs` > `Zendesk API`.
 1. Under `Settings`:
-    - To enable username/password auth, toggle `Password access` to `Enabled`. (Not recommended)
-    - To enable API token authentication (API Key), toggle `Token access` to `Enabled`, and click `Add API token`. Note that you will need to append `/token` to the end of your username (email) if you are using this option. (Recommended)
+    - To enable API token authentication (API Key), toggle `Token access` to `Enabled`, and click `Add API token`. Note that you will need to append `/token` to the end of your username (email) if you are using this option.
 1. You will now be able to use `{your_email}/token` and the generated `API token` to access Zendesk's API, where `your_email` is the email of your verified (or unverified) user. You should use these credentials when adding your custom extension to your assistant.
 
 ![Create API Key](./assets/create-api-key.gif)<br>


### PR DESCRIPTION
Zendesk will soon remove support for using email and password for authentication : https://support.zendesk.com/hc/en-us/articles/7386291855386-Announcing-the-deprecation-of-password-access-for-APIs.

This means we remove instructions for using password auth.