### PR TITLE
fix: update watsonx.ai extension hash in the actions JSON

### DIFF
--- a/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
@@ -955,7 +955,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
+                  "spec_hash_id": "8839e74834d1df3e58d9899f17298627c23c528c6bedb09f4532c40de3d7883c",
                   "catalog_item_id": "062424d3-3a2d-4ca3-a985-d66c01a209ee"
                 },
                 "request_mapping": {

--- a/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/discovery-watsonx-actions.json
@@ -494,7 +494,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
+                  "spec_hash_id": "3408d5415323ca392bb94b1fdfd03f6259f0ff1e35a65e5750e2740ba2908435",
                   "catalog_item_id": "16bf38b2-037f-4f95-87d3-77ad737b3c0f"
                 },
                 "request_mapping": {
@@ -955,7 +955,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "8839e74834d1df3e58d9899f17298627c23c528c6bedb09f4532c40de3d7883c",
+                  "spec_hash_id": "8566081a305e8f8ade4e9bd3887da0600e87948417fc10ba38ee121426f8c50b",
                   "catalog_item_id": "062424d3-3a2d-4ca3-a985-d66c01a209ee"
                 },
                 "request_mapping": {

--- a/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
+++ b/integrations/extensions/starter-kits/language-model-conversational-search/elasticsearch-watsonx-actions.json
@@ -987,7 +987,7 @@
                 "type": "integration_interaction",
                 "method": "POST",
                 "internal": {
-                  "spec_hash_id": "fee06cd24334b3cb80a4d75c28882b1bdaf910e93ce214f1a4e0d48840e518de",
+                  "spec_hash_id": "3408d5415323ca392bb94b1fdfd03f6259f0ff1e35a65e5750e2740ba2908435",
                   "match_scenario": 1,
                   "catalog_item_id": "c3899a4f-2ba6-4427-8ff3-823a0a5cc7d8"
                 },


### PR DESCRIPTION
This PR fixes the watsonx.ai extension hash ID in the actions JSON for both Elasticsearch and Discovery.
Signed off by: zhongzheng.shu@ibm.com