### PR TITLE
fix: add config for web crawler setup and fix the fscrawler index

### DIFF
--- a/integrations/extensions/docs/elasticsearch-install-and-setup/how_to_index_pdf_and_office_documents_elasticsearch.md
+++ b/integrations/extensions/docs/elasticsearch-install-and-setup/how_to_index_pdf_and_office_documents_elasticsearch.md
@@ -50,21 +50,8 @@ curl -X PUT "${ES_URL}/${ES_INDEX_NAME}?pretty" -u "${ES_USER}:${ES_PASSWORD}" \
       "passages": {
         "type": "nested",
         "properties": {
-          "is_truncated": {
-            "type": "boolean"
-          },
           "text": {
-            "type": "keyword",
-            "ignore_above": 2048
-          },
-          "model_id": {
-            "type": "text",
-            "fields": {
-              "keyword": {
-                "type": "keyword",
-                "ignore_above": 256
-              }
-            }
+            "type": "text"
           },
           "sparse": {
             "properties": {

--- a/integrations/extensions/docs/elasticsearch-install-and-setup/how_to_use_web_crawler_in_elasticsearch.md
+++ b/integrations/extensions/docs/elasticsearch-install-and-setup/how_to_use_web_crawler_in_elasticsearch.md
@@ -79,8 +79,16 @@ In a new terminal window, run the following command to generate an encryption ke
     --env "elasticsearch.ssl.enabled=true" \
     --env "elasticsearch.ssl.certificate_authority=/usr/share/enterprise-search/es-config/${ES_CACERT_NAME}" \
     --env "kibana.external_url=http://kibana:5601" \
+    --env "connector.crawler.content_extraction.enabled=true" \
+    --env "connector.crawler.content_extraction.mime_types=["application/pdf", "application/msword"]" \
+    --env "connector.crawler.http.response_size.limit=10485760" \
     "docker.elastic.co/enterprise-search/enterprise-search:${ES_VERSION}"
     ```
+  NOTES:
+  * `connector.crawler.content_extraction.enabled=true` enables binary content extraction. It is required to extract content from downloadable binary files, such as PDF and DOCX files.
+  * `connector.crawler.content_extraction.mime_types=["application/pdf", "application/msword"]` specifies which MIME types should have their contents extracted.
+  * `connector.crawler.http.response_size.limit=10485760` set the maximum size of an HTTP response (in bytes) supported by the Elastic web crawler. The default limit is `10485760` bytes or 10MB. You can increase it if needed.
+  * To learn more, see [Elastic web crawler configuration](https://www.elastic.co/guide/en/enterprise-search/current/configuration.html#configuration-settings-elastic-crawler).
 * Verify the installation 
   * Open http://localhost:5601 in your browser and log into Kibana using your Elasticsearch username and password.
   * Navigate to the Search Overview page http://localhost:5601/app/enterprise_search/overview.


### PR DESCRIPTION
This PR adds new configs for starting enterprise search to support the web crawler extracting downloadable binary files. It also fixes the index mappings when using fscrawler to ingest documents. These are findings from working on customer issues and requests. 

Signed off by: zhongzheng.shu@ibm.com