### PR TITLE
fix(OAuth2): Improve Auth Code Flow

### DIFF
--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/client-cred.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/client-cred.js
@@ -1,11 +1,12 @@
 // Authorization codes storage (code -> expireTime)
-const authCodes = new Map();
+import crypto from "node:crypto";
+
 export const accessTokensClientCred = new Map();
 const refreshToken = 'client-cred-refresh-token';
 
 function issueAccessToken() {
   // Issue a new access_token
-  const accessToken = Math.random().toString(36).slice(-8)
+  const accessToken = crypto.randomUUID().toString();
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensClientCred.set(accessToken, accessExpireTime)
   console.log(`[client cred] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/custom-apikey.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/custom-apikey.js
@@ -1,12 +1,13 @@
 // Authorization codes storage (code -> expireTime)
-const authCodes = new Map();
+import crypto from "node:crypto";
+
 export const accessTokensCustomApikey = new Map();
 accessTokensCustomApikey.set('custom', 0)
 const refreshToken = 'custom-refresh-token';
 
 function issueAccessToken() {
   // Issue a new access_token
-  const accessToken = Math.random().toString(36).slice(-8)
+  const accessToken = crypto.randomUUID().toString();
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensCustomApikey.set(accessToken, accessExpireTime)
 

--- a/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/password.js
+++ b/integrations/extensions/starter-kits/testitall/mock-server/server/controllers/oauth-providers/password.js
@@ -1,9 +1,11 @@
+import crypto from "node:crypto";
+
 export const accessTokensPassword = new Map();
 const refreshToken = 'password-refresh-token';
 
 function issueAccessToken() {
   // Issue a new access_token
-  const accessToken = Math.random().toString(36).slice(-8)
+  const accessToken = crypto.randomUUID().toString();
   const accessExpireTime = Date.now() + 1000 * parseInt(process.env.OAUTH_ACCESS_TOKEN_EXPIRES, 10)
   accessTokensPassword.set(accessToken, accessExpireTime)
   console.log(`[password] Issuing token: ${accessToken}, expires: ${new Date(accessExpireTime)}`)

--- a/integrations/extensions/starter-kits/testitall/package-lock.json
+++ b/integrations/extensions/starter-kits/testitall/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "testitall",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Changes have been introduced to the authorize endpoint so that the query parameter `response_format` may be set to the value `json` to make the authorization endpoint return JSON response data rather than a jump page. This has been implemented to facilitate smoother API side testing of OAuth2 Authorization Code flow. Efforts have also been taken to ensure that the generated authorization code is returned along with the expiry time to further facilitate easier API testing.

Lastly, the system has also been updated to generate a UUID as the auth code.